### PR TITLE
Get form submissions by form or submisssion id

### DIFF
--- a/src/resources/forms/dto/submission-get.dto.ts
+++ b/src/resources/forms/dto/submission-get.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsObject } from 'class-validator';
+
+export class SubmissionGetDto {
+  @ApiProperty()
+  @IsNumber()
+  responseId: number;
+  @ApiProperty()
+  @IsObject()
+  responses: Record<string, unknown>;
+}

--- a/src/resources/forms/dto/submission-get.dto.ts
+++ b/src/resources/forms/dto/submission-get.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber, IsObject } from 'class-validator';
+import { FormFieldResponses } from '../../../entities/formFieldResponses.entity';
 
 export class SubmissionGetDto {
   @ApiProperty()
   @IsNumber()
-  responseId: number;
+  submissionId: number;
   @ApiProperty()
   @IsObject()
-  responses: Record<string, unknown>;
+  responses: FormFieldResponses[];
 }

--- a/src/resources/forms/submissions/submissions.controller.ts
+++ b/src/resources/forms/submissions/submissions.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { ApiParam, ApiTags } from '@nestjs/swagger';
 import { SubmissionsService } from './submissions.service';
 import { SubmitFormDto } from '../dto/submit-form.dto';
@@ -22,7 +22,25 @@ export class SubmissionsController {
       +confId,
       +formId,
       submitFormDto,
-      register,
     );
+  }
+
+  @Get('')
+  @ApiParam({ name: 'conferenceId' })
+  @ApiParam({ name: 'formId' })
+  getAll(@Param('conferenceId') confId, @Param('formId') formId) {
+    return this.submissionsService.fetchAll(+confId, +formId);
+  }
+
+  @Get(':submissionId')
+  @ApiParam({ name: 'conferenceId' })
+  @ApiParam({ name: 'formId' })
+  @ApiParam({ name: 'submissionId' })
+  getOne(
+    @Param('conferenceId') confId,
+    @Param('formId') formId,
+    @Param('submissionId') submissionId,
+  ) {
+    return this.submissionsService.fetchOne(+confId, +formId, +submissionId);
   }
 }

--- a/src/resources/forms/submissions/submissions.controller.ts
+++ b/src/resources/forms/submissions/submissions.controller.ts
@@ -1,7 +1,16 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
-import { ApiParam, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiParam, ApiTags } from '@nestjs/swagger';
 import { SubmissionsService } from './submissions.service';
 import { SubmitFormDto } from '../dto/submit-form.dto';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 
 @ApiTags('formSubmissions')
 @Controller('conferences/:conferenceId/forms/:formId/submissions')
@@ -26,6 +35,8 @@ export class SubmissionsController {
   }
 
   @Get('')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiParam({ name: 'conferenceId' })
   @ApiParam({ name: 'formId' })
   getAll(@Param('conferenceId') confId, @Param('formId') formId) {
@@ -33,9 +44,12 @@ export class SubmissionsController {
   }
 
   @Get(':submissionId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiParam({ name: 'conferenceId' })
   @ApiParam({ name: 'formId' })
   @ApiParam({ name: 'submissionId' })
+  @UseGuards(JwtAuthGuard)
   getOne(
     @Param('conferenceId') confId,
     @Param('formId') formId,

--- a/src/resources/forms/submissions/submissions.service.ts
+++ b/src/resources/forms/submissions/submissions.service.ts
@@ -128,7 +128,7 @@ export class SubmissionsService {
         }
       });
 
-      // If the object has values other than "id", add to output array
+      // If the object has values other than just "id", add to output array
       if (Object.keys(responsesObj).length > 1) {
         output.push(responsesObj);
       }

--- a/src/resources/forms/submissions/submissions.service.ts
+++ b/src/resources/forms/submissions/submissions.service.ts
@@ -49,6 +49,7 @@ export class SubmissionsService {
    * @param submissionId
    */
   async fetchOne(confId, formId, submissionId) {
+    // TODO: Verify conference with confId has a form of formId with submissions of submissionId
     // Get map of fieldValues
     const fieldValues = await this.getFieldValues();
 
@@ -82,6 +83,7 @@ export class SubmissionsService {
    * @param formId
    */
   async fetchAll(confId, formId) {
+    // TODO: Verify conference with confId has a form of formId
     // Get all submission IDs corresponding to formId
     const submissionIdsQuery: FormSubmissions[] =
       await this.submissionRepository.find({

--- a/src/resources/forms/submissions/submissions.service.ts
+++ b/src/resources/forms/submissions/submissions.service.ts
@@ -94,20 +94,16 @@ export class SubmissionsService {
     );
 
     /**
-     * This is fun, lots of fun Map and .map tricks.
+     * All of this just to generate the output below
      */
 
-    /**
-     * Because responses come in as an array of objects, each representing a
-     * row, a map must be used before the final response can be generated, where
-     * the key is the submissionId, and the value is an object of responses for
-     * each field.
-     */
-    const submissions = new Map();
+    const output = [];
 
+    // Cheeky way to iterate through the submission ids
     submissionIds.map((id) => {
-      const responsesObj = {};
+      const responsesObj = { id };
 
+      // for each submission id, we want all the corresponding responses so:
       responses.map((response) => {
         if (response.submission_id === id) {
           // Value of the response to the content
@@ -116,6 +112,7 @@ export class SubmissionsService {
           // FieldType for the response's field
           const fieldType = response.field_type;
 
+          // Transform the data containing ids as needed:
           switch (fieldType) {
             case 'SELECTION':
               val = fieldValues.get(+val);
@@ -126,21 +123,16 @@ export class SubmissionsService {
               break;
           }
 
+          // Set response data into responsesObj
           responsesObj[`${response.content}`] = val;
         }
       });
 
-      submissions.set(id, responsesObj);
-    });
-
-    const output = [];
-
-    for (const submissionIter of submissions) {
-      if (Object.keys(submissionIter[1]).length > 1) {
-        submissionIter[1]['id'] = submissionIter[0];
-        output.push(submissionIter[1]);
+      // If the object has values other than "id", add to output array
+      if (Object.keys(responsesObj).length > 1) {
+        output.push(responsesObj);
       }
-    }
+    });
 
     return output;
   }


### PR DESCRIPTION
Two new endpoints were added at:
- `{API_URL}/conferences/{conferenceId}/forms/{formId}/submissions`
- `{API_URL}/conferences/{conferenceId}/forms/{formId}/submissions/{submissionId}`

Request Method for both is `GET`, empty request body and no query parameters.
Both require authentication to use.

Some technical debts was incurred, specifically that validation of whether a
submission belongs to a conference (for either endpoint) and whether a
submission corresponds to a form. So while the following examples may be
incorrect, they will still retrieve the corresponding responses for the
form or submission with the correct low-level ID:

- `{API_URL}/conferences/1000/forms/2/submissions` - Even if conference `1000`
does not exist, it will still retrieve submissions for form `2`.
- `{API_URL}/conferences/1000/forms/1000/submissions/50` - Even if conference
`1000` or form `1000` do not exist, submission `50` values will still be
retrieved.


